### PR TITLE
Use the right Batch creator to register stats.

### DIFF
--- a/pkg/chunk/cassandra/storage_client.go
+++ b/pkg/chunk/cassandra/storage_client.go
@@ -102,7 +102,7 @@ type writeBatch struct {
 
 func (s *storageClient) NewWriteBatch() chunk.WriteBatch {
 	return writeBatch{
-		b: gocql.NewBatch(gocql.UnloggedBatch),
+		b: s.session.NewBatch(gocql.UnloggedBatch),
 	}
 }
 


### PR DESCRIPTION
`gocql.NewBatch` is deprecated and doesn't register the observer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/grafana/cortex/1)
<!-- Reviewable:end -->
