### PR TITLE
Stop sharding amongst distributors by metric name; use all the labels.

### DIFF
--- a/pkg/util/flags.go
+++ b/pkg/util/flags.go
@@ -58,6 +58,41 @@ func (v *DayValue) IsSet() bool {
 	return v.set
 }
 
+// TimeValue is a model.Time that can be used as a flag.
+type TimeValue struct {
+	model.Time
+	set bool
+}
+
+// NewTimeValue makes a new DayValue
+func NewTimeValue(t model.Time) TimeValue {
+	return TimeValue{
+		Time: t,
+		set:  true,
+	}
+}
+
+// String implements flag.Value
+func (v TimeValue) String() string {
+	return v.Time.Time().Format(time.RFC3339)
+}
+
+// Set implements flag.Value
+func (v *TimeValue) Set(s string) error {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return err
+	}
+	v.Time = model.TimeFromUnix(t.Unix())
+	v.set = true
+	return nil
+}
+
+// IsSet returns true is the DayValue has been set.
+func (v *TimeValue) IsSet() bool {
+	return v.set
+}
+
 // URLValue is a url.URL that can be used as a flag.
 type URLValue struct {
 	*url.URL

--- a/pkg/util/flags.go
+++ b/pkg/util/flags.go
@@ -58,41 +58,6 @@ func (v *DayValue) IsSet() bool {
 	return v.set
 }
 
-// TimeValue is a model.Time that can be used as a flag.
-type TimeValue struct {
-	model.Time
-	set bool
-}
-
-// NewTimeValue makes a new DayValue
-func NewTimeValue(t model.Time) TimeValue {
-	return TimeValue{
-		Time: t,
-		set:  true,
-	}
-}
-
-// String implements flag.Value
-func (v TimeValue) String() string {
-	return v.Time.Time().Format(time.RFC3339)
-}
-
-// Set implements flag.Value
-func (v *TimeValue) Set(s string) error {
-	t, err := time.Parse(time.RFC3339, s)
-	if err != nil {
-		return err
-	}
-	v.Time = model.TimeFromUnix(t.Unix())
-	v.set = true
-	return nil
-}
-
-// IsSet returns true is the DayValue has been set.
-func (v *TimeValue) IsSet() bool {
-	return v.set
-}
-
 // URLValue is a url.URL that can be used as a flag.
 type URLValue struct {
 	*url.URL


### PR DESCRIPTION
Sharding by metric name was designed to reduce the number of queriers you need to hit on the read path; the downside was that you could hotspot the write path.

In hindsight, this seems like the wrong choice: we do many orders of magnitude more writes than reads, and ingester reads are in-memory and cheap.  It seems the right thing to do is to use all the labels to shard, improving load balancing and support for very high cardinality metrics.

Signed-off-by: Tom Wilkie <tom.wilkie@gmail.com>