### PR TITLE
Parallelise chunk decoding

### DIFF
--- a/pkg/chunk/cache/cache.go
+++ b/pkg/chunk/cache/cache.go
@@ -20,6 +20,9 @@ type Config struct {
 	memcache       MemcachedConfig
 	memcacheClient MemcachedClientConfig
 	diskcache      DiskcacheConfig
+
+	// For tests to inject specific implementations.
+	Cache Cache
 }
 
 // RegisterFlags adds the flags required to config this to the given FlagSet.
@@ -34,6 +37,10 @@ func (cfg *Config) RegisterFlags(f *flag.FlagSet) {
 
 // New creates a new Cache using Config.
 func New(cfg Config) (Cache, error) {
+	if cfg.Cache != nil {
+		return cfg.Cache, nil
+	}
+
 	caches := []Cache{}
 
 	if cfg.EnableDiskcache {

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -75,26 +75,26 @@ type store struct {
 
 	storage StorageClient
 	schema  Schema
-	*chunkFetcher
+	*Fetcher
 }
 
 func newStore(cfg StoreConfig, schema Schema, storage StorageClient) (Store, error) {
-	fetcher, err := newChunkFetcher(cfg.CacheConfig, storage)
+	fetcher, err := NewChunkFetcher(cfg.CacheConfig, storage)
 	if err != nil {
 		return nil, err
 	}
 
 	return &store{
-		cfg:          cfg,
-		storage:      storage,
-		schema:       schema,
-		chunkFetcher: fetcher,
+		cfg:     cfg,
+		storage: storage,
+		schema:  schema,
+		Fetcher: fetcher,
 	}, nil
 }
 
 // Stop any background goroutines (ie in the cache.)
 func (c *store) Stop() {
-	c.chunkFetcher.Stop()
+	c.Fetcher.Stop()
 }
 
 // Put implements ChunkStore
@@ -243,7 +243,7 @@ func (c *store) getMetricNameChunks(ctx context.Context, from, through model.Tim
 	}
 
 	// Now fetch the actual chunk data from Memcache / S3
-	allChunks, err := c.fetchChunks(ctx, filtered, keys)
+	allChunks, err := c.FetchChunks(ctx, filtered, keys)
 	if err != nil {
 		return nil, promql.ErrStorage(err)
 	}

--- a/pkg/chunk/chunk_store.go
+++ b/pkg/chunk/chunk_store.go
@@ -94,7 +94,7 @@ func newStore(cfg StoreConfig, schema Schema, storage StorageClient) (Store, err
 
 // Stop any background goroutines (ie in the cache.)
 func (c *store) Stop() {
-	c.cache.Stop()
+	c.chunkFetcher.Stop()
 }
 
 // Put implements ChunkStore

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -461,9 +461,7 @@ func TestChunkStoreLeastRead(t *testing.T) {
 		}
 
 		chunks, err := store.Get(ctx, startTime, endTime, matchers...)
-		if err != nil {
-			t.Fatal(t, err)
-		}
+		require.NoError(t, err)
 
 		// We need to check that each chunk is in the time range
 		for _, chunk := range chunks {

--- a/pkg/chunk/chunk_store_test.go
+++ b/pkg/chunk/chunk_store_test.go
@@ -207,6 +207,7 @@ func TestChunkStore_Get(t *testing.T) {
 			t.Run(fmt.Sprintf("%s / %s", tc.query, schema.name), func(t *testing.T) {
 				t.Log("========= Running query", tc.query, "with schema", schema.name)
 				store := newTestChunkStore(t, schema.schemaFn, schema.storeFn)
+				defer store.Stop()
 
 				if err := store.Put(ctx, []Chunk{
 					fooChunk1,
@@ -324,6 +325,7 @@ func TestChunkStore_getMetricNameChunks(t *testing.T) {
 			t.Run(fmt.Sprintf("%s / %s", tc.query, schema.name), func(t *testing.T) {
 				t.Log("========= Running query", tc.query, "with schema", schema.name)
 				store := newTestChunkStore(t, schema.schemaFn, schema.storeFn)
+				defer store.Stop()
 
 				if err := store.Put(ctx, []Chunk{chunk1, chunk2}); err != nil {
 					t.Fatal(err)
@@ -359,6 +361,7 @@ func TestChunkStoreRandom(t *testing.T) {
 	for _, schema := range schemas {
 		t.Run(schema.name, func(t *testing.T) {
 			store := newTestChunkStore(t, schema.schemaFn, schema.storeFn)
+			defer store.Stop()
 
 			// put 100 chunks from 0 to 99
 			const chunkLen = 13 * 3600 // in seconds
@@ -422,6 +425,7 @@ func TestChunkStoreLeastRead(t *testing.T) {
 	// Test we don't read too much from the index
 	ctx := user.InjectOrgID(context.Background(), userID)
 	store := newTestChunkStore(t, v6Schema, newStore)
+	defer store.Stop()
 
 	// Put 24 chunks 1hr chunks in the store
 	const chunkLen = 60 // in seconds

--- a/pkg/chunk/chunk_store_utils.go
+++ b/pkg/chunk/chunk_store_utils.go
@@ -100,8 +100,9 @@ func newChunkFetcher(cfg cache.Config, storage StorageClient) (*chunkFetcher, er
 	}
 
 	c := &chunkFetcher{
-		storage: storage,
-		cache:   cache,
+		storage:        storage,
+		cache:          cache,
+		decodeRequests: make(chan decodeRequest),
 	}
 
 	c.wait.Add(chunkDecodeParallelism)

--- a/pkg/chunk/series_store.go
+++ b/pkg/chunk/series_store.go
@@ -26,17 +26,17 @@ type seriesStore struct {
 }
 
 func newSeriesStore(cfg StoreConfig, schema Schema, storage StorageClient) (Store, error) {
-	fetcher, err := newChunkFetcher(cfg.CacheConfig, storage)
+	fetcher, err := NewChunkFetcher(cfg.CacheConfig, storage)
 	if err != nil {
 		return nil, err
 	}
 
 	return &seriesStore{
 		store: store{
-			cfg:          cfg,
-			storage:      storage,
-			schema:       schema,
-			chunkFetcher: fetcher,
+			cfg:     cfg,
+			storage: storage,
+			schema:  schema,
+			Fetcher: fetcher,
 		},
 		cardinalityCache: newFifoCache(cfg.CardinalityCacheSize),
 	}, nil
@@ -95,7 +95,7 @@ func (c *seriesStore) Get(ctx context.Context, from, through model.Time, allMatc
 	}
 
 	// Now fetch the actual chunk data from Memcache / S3
-	allChunks, err := c.fetchChunks(ctx, filtered, keys)
+	allChunks, err := c.FetchChunks(ctx, filtered, keys)
 	if err != nil {
 		level.Error(log).Log("err", err)
 		return nil, err


### PR DESCRIPTION
Chunk decoding is already parallelised when fetching from bigtable, but for memcache it is not.

Uses a worker pool of 16 goroutines to decode chunks in parallel.